### PR TITLE
Allow to use T0 even with 1 extruder

### DIFF
--- a/panels/extrude.py
+++ b/panels/extrude.py
@@ -58,7 +58,7 @@ class Panel(ScreenPanel):
         i = 0
         for extruder in self._printer.get_tools():
             if self._printer.extrudercount > 1:
-                self.labels[extruder] = self._gtk.Button(f"extruder-{i}", f"T{self._printer.get_tool_number(extruder)}")                
+                self.labels[extruder] = self._gtk.Button(f"extruder-{i}", f"T{self._printer.get_tool_number(extruder)}")
             else:
                 self.labels[extruder] = self._gtk.Button("extruder", "")
             self.labels[extruder].connect("clicked", self.change_extruder, extruder)

--- a/panels/extrude.py
+++ b/panels/extrude.py
@@ -58,10 +58,10 @@ class Panel(ScreenPanel):
         i = 0
         for extruder in self._printer.get_tools():
             if self._printer.extrudercount > 1:
-                self.labels[extruder] = self._gtk.Button(f"extruder-{i}", f"T{self._printer.get_tool_number(extruder)}")
-                self.labels[extruder].connect("clicked", self.change_extruder, extruder)
+                self.labels[extruder] = self._gtk.Button(f"extruder-{i}", f"T{self._printer.get_tool_number(extruder)}")                
             else:
                 self.labels[extruder] = self._gtk.Button("extruder", "")
+            self.labels[extruder].connect("clicked", self.change_extruder, extruder)
             if extruder == self.current_extruder:
                 self.labels[extruder].get_style_context().add_class("button_active")
             if i < limit:


### PR DESCRIPTION
I think it still a useful button, which can be used with a redefined T0 macro, which could be utilized with cooling down a hotend for example.

I had this on my printer before the update:

```
[gcode_macro T0]
description: When I press extruder button on the Extrude screnn in KlipperScreen
gcode:
  SET_HEATER_TEMPERATURE HEATER=extruder TARGET=0
```