### PR TITLE
Fix fullscreen issue when setting width or height in config for non-desktop machines

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -127,11 +127,13 @@ class KlipperScreen(Gtk.Window):
         self.width = self._config.get_main_config().getint("width", None)
         self.height = self._config.get_main_config().getint("height", None)
         if 'XDG_CURRENT_DESKTOP' in os.environ:
+            logging.warning("Running inside a desktop environment is not recommended")
             if not self.width:
                 self.width = max(int(monitor.get_geometry().width * .5), 480)
             if not self.height:
                 self.height = max(int(monitor.get_geometry().height * .5), 320)
         if self.width or self.height:
+            logging.info("Setting windowed mode")
             self.set_resizable(True)
             self.windowed = True
         else:

--- a/screen.py
+++ b/screen.py
@@ -131,6 +131,7 @@ class KlipperScreen(Gtk.Window):
                 self.width = max(int(monitor.get_geometry().width * .5), 480)
             if not self.height:
                 self.height = max(int(monitor.get_geometry().height * .5), 320)
+        if self.width or self.height:
             self.set_resizable(True)
             self.windowed = True
         else:


### PR DESCRIPTION
Setting width and height in the config should result in a windowed screen, but it is only the case for desktop users. 
Fixes https://github.com/KlipperScreen/KlipperScreen/issues/1176 introduced via 8f07f21