### PR TITLE
config: refactor install language, fix issues with getlocale on mac

### DIFF
--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -116,24 +116,23 @@ class KlipperScreenConfig:
 
         lang = self.get_main_config().get("language", None)
         logging.debug(f"Selected lang: {lang} OS lang: {locale.getlocale()[0]}")
+        if lang not in self.lang_list:
+            lang = self.find_language(lang)
         self.install_language(lang)
 
+    def find_language(self, lang):
+        if lang in (None, "system_lang"):
+            sys_lang = locale.getlocale()[0]
+            if sys_lang is None or len(sys_lang) < 2:
+                return "en"
+            if sys_lang in self.lang_list:
+                return sys_lang
+            for language in self.lang_list:
+                if sys_lang.startswith(language):
+                    return language
+        return next((language for language in self.lang_list if lang.startswith(language)), "en")
+
     def install_language(self, lang):
-        if lang is None or lang == "system_lang":
-            for language in self.lang_list:
-                if locale.getlocale()[0].startswith(language):
-                    logging.debug("Using system lang")
-                    lang = language
-        if lang is not None and lang not in self.lang_list:
-            # try to match a parent
-            for language in self.lang_list:
-                if lang.startswith(language):
-                    lang = language
-                    self.set("main", "language", lang)
-        if lang not in self.lang_list:
-            logging.error(f"lang: {lang} not found")
-            logging.info(f"Available lang list {self.lang_list}")
-            lang = "en"
         logging.info(f"Using lang {lang}")
         self.lang = self.langs[lang]
         self.lang.install(names=['gettext', 'ngettext'])


### PR DESCRIPTION
@rafaelSwi mentioned an issue with the language on mac in #1246 

the issue seems that get locale can return None (and investigating in some cases just one letter)
i ended changing it a lot to make it more understandable