### PR TITLE
Fix bed level complete icon

### DIFF
--- a/panels/bed_level.py
+++ b/panels/bed_level.py
@@ -351,7 +351,7 @@ class Panel(ScreenPanel):
                                 self.buttons[key].set_label(_("Reference"))
                             else:
                                 self.buttons[key].set_label(f"{result['sign']} {result['adjust']}")
-                            if int(result['adjust'].split(':')[0]) == 0 and int(result['adjust'].split(':')[1]) < 6 :
+                            if int(result['adjust'].split(':')[0]) == 0 and int(result['adjust'].split(':')[1]) < 6:
                                 self.buttons[key].set_image(self._gtk.Image('complete'))
                             else:
                                 self.buttons[key].set_image(self._gtk.Image(result['sign'].lower()))

--- a/panels/bed_level.py
+++ b/panels/bed_level.py
@@ -351,7 +351,7 @@ class Panel(ScreenPanel):
                                 self.buttons[key].set_label(_("Reference"))
                             else:
                                 self.buttons[key].set_label(f"{result['sign']} {result['adjust']}")
-                            if int(result['adjust'].split(':')[1]) < 6:
+                            if int(result['adjust'].split(':')[0]) == 0 and int(result['adjust'].split(':')[1]) < 6 :
                                 self.buttons[key].set_image(self._gtk.Image('complete'))
                             else:
                                 self.buttons[key].set_image(self._gtk.Image(result['sign'].lower()))


### PR DESCRIPTION
This pull request fixes issue #1267.
The code was only checking the minutes, so when the hour was greater than 0, it still displayed the checkmark icon. This modification now also examines the hours.