### PR TITLE
Improve params pattern to catch more macros

### DIFF
--- a/panels/gcode_macros.py
+++ b/panels/gcode_macros.py
@@ -80,7 +80,7 @@ class Panel(ScreenPanel):
             "row": row,
             "params": {},
         }
-        pattern = r'params\.(?P<param>..*)\|default\((?P<default>..*)\).*'
+        pattern = r'params\.(?P<param>[A-Z_0-9]+)(?:\s*\|.*\s*default\(\s*(?P<default>[^\)]+)\))?'
         i = 0
         for line in gcode:
             if line.startswith("{") and "params." in line:


### PR DESCRIPTION
Hello, 
The current pattern can only take into account params followed by default. The proposal catches more parameters and removes white spaces if present to avoid error sending macro
```elixir
[gcode_macro TEST]
gcode:
        {% set test = params.TEST_0 %}
        {% set test = params.TEST_1    |    default( 0 ) %}
        {% set test = params.TEST_2| int |default(0) %}
```