### PR TITLE
Screen Panel: Fixed emergency stop confirmation process

### DIFF
--- a/ks_includes/screen_panel.py
+++ b/ks_includes/screen_panel.py
@@ -43,7 +43,6 @@ class ScreenPanel:
                                               "printer.emergency_stop")
         else:
             self._screen._ws.klippy.emergency_stop()
-        self._screen._ws.klippy.emergency_stop()
 
     def get_file_image(self, filename, width=None, height=None, small=False):
         if not self._files.has_thumbnail(filename):


### PR DESCRIPTION
Emergency stop was always proceeding without waiting for confirmation, despite the fact that user configured KlipperScreen to confirm emergency stops.

This is a fix for https://github.com/KlipperScreen/KlipperScreen/issues/1344
