### PR TITLE
Added beacon support

### DIFF
--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -62,6 +62,10 @@ class Panel(ScreenPanel):
 
         self.labels['popover'] = Gtk.Popover(position=Gtk.PositionType.BOTTOM)
 
+        self.probe_calibrate = ("BEACON_CALIBRATE"
+                                if "BEACON_CALIBRATE" in self._printer.available_commands
+                                else "PROBE_CALIBRATE")
+
         self.set_functions()
 
         distgrid = Gtk.Grid()
@@ -106,7 +110,8 @@ class Panel(ScreenPanel):
         if "Z_ENDSTOP_CALIBRATE" in self._printer.available_commands:
             self._add_button("Endstop", "endstop", pobox)
             functions.append("endstop")
-        if "PROBE_CALIBRATE" in self._printer.available_commands:
+        if ("PROBE_CALIBRATE" in self._printer.available_commands
+                or "BEACON_CALIBRATE" in self._printer.available_commands):
             self._add_button("Probe", "probe", pobox)
             functions.append("probe")
         if "BED_MESH_CALIBRATE" in self._printer.available_commands:
@@ -169,7 +174,7 @@ class Panel(ScreenPanel):
             self._screen._ws.klippy.gcode_script("BED_MESH_CLEAR")
             if method == "probe":
                 self._move_to_position(*self._get_probe_location())
-                self._screen._ws.klippy.gcode_script("PROBE_CALIBRATE")
+                self._screen._ws.klippy.gcode_script(self.probe_calibrate)
             elif method == "delta":
                 self._screen._ws.klippy.gcode_script("DELTA_CALIBRATE")
             elif method == "delta_manual":


### PR DESCRIPTION
As more and more people are running beacon, it would make sense to allow people to properly use KlipperScreen with that probe.
These changes just check whether the `beacon_calibrate` command exists and adjust accordingly. completely backwards compatible, no breaking change.