### PR TITLE
printer: tempstore fixup

### DIFF
--- a/ks_includes/printer.py
+++ b/ks_includes/printer.py
@@ -396,7 +396,8 @@ class Printer:
             for x in self.tempstore[device]:
                 self.tempstore[device][x].pop(0)
                 temp = self.get_stat(device, x[:-1])
-                if temp is None:
+                if not temp:
+                    # If the temperature is not available, set it to 0.
                     temp = 0
                 self.tempstore[device][x].append(temp)
         return True

--- a/panels/base_panel.py
+++ b/panels/base_panel.py
@@ -256,7 +256,7 @@ class BasePanel(ScreenPanel):
             return
         for device in self._printer.get_temp_devices():
             temp = self._printer.get_stat(device, "temperature")
-            if temp is not None and device in self.labels:
+            if temp and device in self.labels:
                 name = ""
                 if not (device.startswith("extruder") or device.startswith("heater_bed")):
                     if self.titlebar_name_type == "full":


### PR DESCRIPTION
The temperature retrieved from 'get_stat' could be {} if the device is unavailable, potentially resulting in a malfunction of the temperature panel.