### PR TITLE
KlipperScreen Install Fix (Syntax error KlipperScreen-install.sh: line 154)

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -117,7 +117,8 @@ create_virtualenv()
     if [ -d $KSENV ]; then
         echo_text "Removing old virtual environment"
         rm -rf ${KSENV}
-
+    fi
+    
     echo_text "Creating virtual environment"
     python3 -m venv ${KSENV}
 


### PR DESCRIPTION
Fixed Syntax Error from line 154 causing install script to fail.