### PR TITLE
Make Z_ENDSTOP_CALIBRATE call BED_MESH_CLEAR only if bed_mesh enabled

### DIFF
--- a/panels/zcalibrate.py
+++ b/panels/zcalibrate.py
@@ -216,7 +216,8 @@ class Panel(ScreenPanel):
         self.dropdown.set_sensitive(False)
 
         self._screen._ws.klippy.gcode_script("SET_GCODE_OFFSET Z=0")
-        self._screen._ws.klippy.gcode_script("BED_MESH_CLEAR")
+        if self._printer.config_section_exists("bed_mesh"):
+            self._screen._ws.klippy.gcode_script("BED_MESH_CLEAR")
         if self._printer.get_stat("toolhead", "homed_axes") != "xyz":
             self._screen._ws.klippy.gcode_script("G28")
         self._move_to_position(*self._get_calibration_location())


### PR DESCRIPTION
When trying to calibrate the Z Endstop on a printer without mesh bed leveling, it throws an error popup because `BED_MESH_CLEAR` is not defined. This PR adds a check to only run that macro if `bed_mesh` is defined in Klipper.

I've tested the modification and it works as expected