### PR TITLE
Moonraker route prefix support

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -49,8 +49,13 @@ Multiple printers can be defined
 [printer MyPrinter]
 # Define the moonraker host/port if different from 127.0.0.1 and 7125
 moonraker_host: 127.0.0.1
-# ports 443 and 7130 will use https/wss
 moonraker_port: 7125
+# Use HTTPS/WSS. Defaults to True for ports 443 or 7130, False for any other port
+# moonraker_ssl: False
+# If you're using the route_prefix option in your moonraker config, specify it here.
+# This can be useful for running multiple printers behind a path-based reverse proxy.
+# Most installs will not need this. 
+# moonraker_path: printer1
 # Moonraker API key if this host is not connecting from a trusted client IP
 # moonraker_api_key: False
 

--- a/ks_includes/KlippyRest.py
+++ b/ks_includes/KlippyRest.py
@@ -4,15 +4,23 @@ import requests
 
 
 class KlippyRest:
-    def __init__(self, ip, port=7125, api_key=False):
+    def __init__(self, ip, port=7125, api_key=False, path='', ssl=None):
         self.ip = ip
         self.port = port
+        self.path = path
+        self.ssl = ssl
+        if (ssl == None):
+            if (self.port in {443, 7130}):
+                self.ssl = True
+            else:
+                self.ssl = False
         self.api_key = api_key
         self.status = ''
 
     @property
     def endpoint(self):
-        return f"{'https' if int(self.port) in {443, 7130} else 'http'}://{self.ip}:{self.port}"
+        # return f"{'https' if int(self.port) in {443, 7130} else 'http'}://{self.ip}:{self.port}"
+        return f"{'https' if (self.ssl == True) else 'http'}://{self.ip}:{self.port}{'/' + self.path if (self.path != '') else ''}"
 
     @staticmethod
     def process_response(response):

--- a/ks_includes/KlippyRest.py
+++ b/ks_includes/KlippyRest.py
@@ -8,19 +8,18 @@ class KlippyRest:
         self.ip = ip
         self.port = port
         self.path = path
-        self.ssl = ssl
+        self.ssl = bool(ssl)
+        self.api_key = api_key
         if (ssl == None):
-            if (self.port in {443, 7130}):
+            if (int(self.port) in {443, 7130}):
                 self.ssl = True
             else:
                 self.ssl = False
-        self.api_key = api_key
         self.status = ''
 
     @property
     def endpoint(self):
-        # return f"{'https' if int(self.port) in {443, 7130} else 'http'}://{self.ip}:{self.port}"
-        return f"{'https' if (self.ssl == True) else 'http'}://{self.ip}:{self.port}{'/' + self.path if (self.path != '') else ''}"
+        return f"{'https' if self.ssl else 'http'}://{self.ip}:{self.port}{'/' + self.path if (self.path != '') else ''}"
 
     @staticmethod
     def process_response(response):

--- a/ks_includes/KlippyRest.py
+++ b/ks_includes/KlippyRest.py
@@ -8,7 +8,7 @@ class KlippyRest:
         self.ip = ip
         self.port = port
         self.path = path
-        self.ssl = bool(ssl)
+        self.ssl = ssl
         self.api_key = api_key
         if (ssl == None):
             if (int(self.port) in {443, 7130}):

--- a/ks_includes/KlippyRest.py
+++ b/ks_includes/KlippyRest.py
@@ -7,19 +7,15 @@ class KlippyRest:
     def __init__(self, ip, port=7125, api_key=False, path='', ssl=None):
         self.ip = ip
         self.port = port
-        self.path = path
+        self.path = f"/{path}" if path else ''
         self.ssl = ssl
         self.api_key = api_key
-        if (ssl == None):
-            if (int(self.port) in {443, 7130}):
-                self.ssl = True
-            else:
-                self.ssl = False
+        self.ssl = int(self.port) in {443, 7130} if ssl is None else bool(ssl)
         self.status = ''
 
     @property
     def endpoint(self):
-        return f"{'https' if self.ssl else 'http'}://{self.ip}:{self.port}{'/' + self.path if (self.path != '') else ''}"
+        return f"{'https' if self.ssl else 'http'}://{self.ip}:{self.port}{self.path}"
 
     @staticmethod
     def process_response(response):

--- a/ks_includes/KlippyWebsocket.py
+++ b/ks_includes/KlippyWebsocket.py
@@ -33,7 +33,7 @@ class KlippyWebsocket(threading.Thread):
         self.path = path
         self.ssl = ssl
         if (ssl == None):
-            if (self.port in {443, 7130}):
+            if (int(self.port) in {443, 7130}):
                 self.ssl = True
             else:
                 self.ssl = False

--- a/ks_includes/KlippyWebsocket.py
+++ b/ks_includes/KlippyWebsocket.py
@@ -30,29 +30,18 @@ class KlippyWebsocket(threading.Thread):
         self.closing = False
         self.host = host
         self.port = port
-        self.path = path
-        self.ssl = ssl
-        if (ssl == None):
-            if (int(self.port) in {443, 7130}):
-                self.ssl = True
-            else:
-                self.ssl = False
+        self.path = f"/{path}" if path else ''
+        self.ssl = int(self.port) in {443, 7130} if ssl is None else bool(ssl)
         self.header = {"x-api-key": api_key} if api_key else {}
         self.api_key = api_key
 
     @property
     def _url(self):
-        if (self.path == ''):
-            return f"{self.host}:{self.port}"
-        else:
-            return f"{self.host}:{self.port}/{self.path}"
+        return f"{self.host}:{self.port}{self.path}"
 
     @property
     def ws_proto(self):
-        if (self.ssl == True):
-            return "wss"
-        else:
-            return "ws"
+        return "wss" if self.ssl else "ws"
 
     def initial_connect(self):
         if self.connect() is not False:

--- a/ks_includes/KlippyWebsocket.py
+++ b/ks_includes/KlippyWebsocket.py
@@ -20,7 +20,7 @@ class KlippyWebsocket(threading.Thread):
     reconnect_count = 0
     max_retries = 4
 
-    def __init__(self, callback, host, port, api_key):
+    def __init__(self, callback, host, port, api_key, path='', ssl=None):
         threading.Thread.__init__(self)
         self._wst = None
         self.ws_url = None
@@ -30,16 +30,29 @@ class KlippyWebsocket(threading.Thread):
         self.closing = False
         self.host = host
         self.port = port
+        self.path = path
+        self.ssl = ssl
+        if (ssl == None):
+            if (self.port in {443, 7130}):
+                self.ssl = True
+            else:
+                self.ssl = False
         self.header = {"x-api-key": api_key} if api_key else {}
         self.api_key = api_key
 
     @property
     def _url(self):
-        return f"{self.host}:{self.port}"
+        if (self.path == ''):
+            return f"{self.host}:{self.port}"
+        else:
+            return f"{self.host}:{self.port}/{self.path}"
 
     @property
     def ws_proto(self):
-        return "wss" if int(self.port) in {443, 7130} else "ws"
+        if (self.ssl == True):
+            return "wss"
+        else:
+            return "ws"
 
     def initial_connect(self):
         if self.connect() is not False:

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -98,6 +98,8 @@ class KlipperScreenConfig:
             {printer[8:]: {
                 "moonraker_host": self.config.get(printer, "moonraker_host", fallback="127.0.0.1"),
                 "moonraker_port": self.config.get(printer, "moonraker_port", fallback="7125"),
+                "moonraker_path": self.config.get(printer, "moonraker_path", fallback='').strip('/'),
+                "moonraker_ssl": self.config.get(printer, "moonraker_ssl", fallback=None),
                 "moonraker_api_key": self.config.get(printer, "moonraker_api_key", fallback="").replace('"', '')
             }} for printer in printers
         ]
@@ -173,10 +175,10 @@ class KlipperScreenConfig:
                 )
             elif section.startswith('printer '):
                 bools = (
-                    'invert_x', 'invert_y', 'invert_z',
+                    'invert_x', 'invert_y', 'invert_z', 'moonraker_ssl', 
                 )
                 strs = (
-                    'moonraker_api_key', 'moonraker_host', 'titlebar_name_type',
+                    'moonraker_api_key', 'moonraker_host', 'moonraker_path', 'titlebar_name_type',
                     'screw_positions', 'power_devices', 'titlebar_items', 'z_babystep_values',
                     'extrude_distances', 'extrude_speeds', 'move_distances', 'zcalibrate_custom_commands'
                 )

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -99,7 +99,7 @@ class KlipperScreenConfig:
                 "moonraker_host": self.config.get(printer, "moonraker_host", fallback="127.0.0.1"),
                 "moonraker_port": self.config.get(printer, "moonraker_port", fallback="7125"),
                 "moonraker_path": self.config.get(printer, "moonraker_path", fallback='').strip('/'),
-                "moonraker_ssl": self.config.get(printer, "moonraker_ssl", fallback=None),
+                "moonraker_ssl": self.config.getboolean(printer, "moonraker_ssl", fallback=None),
                 "moonraker_api_key": self.config.get(printer, "moonraker_api_key", fallback="").replace('"', '')
             }} for printer in printers
         ]

--- a/ks_includes/config.py
+++ b/ks_includes/config.py
@@ -175,7 +175,7 @@ class KlipperScreenConfig:
                 )
             elif section.startswith('printer '):
                 bools = (
-                    'invert_x', 'invert_y', 'invert_z', 'moonraker_ssl', 
+                    'invert_x', 'invert_y', 'invert_z', 'moonraker_ssl',
                 )
                 strs = (
                     'moonraker_api_key', 'moonraker_host', 'moonraker_path', 'titlebar_name_type',

--- a/screen.py
+++ b/screen.py
@@ -238,6 +238,8 @@ class KlipperScreen(Gtk.Window):
             self.printers[ind][name]["moonraker_host"],
             self.printers[ind][name]["moonraker_port"],
             self.printers[ind][name]["moonraker_api_key"],
+            self.printers[ind][name]["moonraker_path"],
+            self.printers[ind][name]["moonraker_ssl"],
         )
         self._ws = KlippyWebsocket(
             {
@@ -249,6 +251,8 @@ class KlipperScreen(Gtk.Window):
             self.printers[ind][name]["moonraker_host"],
             self.printers[ind][name]["moonraker_port"],
             self.printers[ind][name]["moonraker_api_key"],
+            self.printers[ind][name]["moonraker_path"],
+            self.printers[ind][name]["moonraker_ssl"],
         )
         if self.files is None:
             self.files = KlippyFiles(self)


### PR DESCRIPTION
Added optional `moonraker_path` config directive to allow connecting to a moonraker instance that uses a route prefix.
Added optional `moonraker_ssl` config directive to explicitly specify whether SSL/TLS should be enabled.
