### PR TITLE
camera: don't use scale filter if angle is zero

### DIFF
--- a/panels/camera.py
+++ b/panels/camera.py
@@ -59,7 +59,12 @@ class Panel(ScreenPanel):
             vf += "hflip,"
         if cam["flip_vertical"]:
             vf += "vflip,"
-        vf += f"rotate:{cam['rotation'] * 3.14159 / 180}"
+        # Rotation filter is expensive. Omit it if angle is 0
+        if cam["rotation"] != 0:
+            vf += f"rotate:{cam['rotation'] * 3.14159 / 180}"
+        # Remove trailing comma is there is any
+        if len(vf) > 0 and vf[-1] == ',':
+            vf = vf[:-1]
         logging.info(f"video filters: {vf}")
 
         if self.mpv:


### PR DESCRIPTION
scale filter seems to be expensive even with angle=0. On my CB1 having vf=rotate:0.0 in mpv arguments results in KlipperScreen using 100% of a single core vs 30% when it's omitted.