### PR TITLE
Fix screen not staying off

### DIFF
--- a/ks_includes/widgets/screensaver.py
+++ b/ks_includes/widgets/screensaver.py
@@ -13,6 +13,9 @@ class ScreenSaver:
         self.screensaver_timeout = None
         self.blackbox = None
 
+    def is_showing(self):
+        return self.blackbox is not None
+
     def reset_timeout(self, *args):
         if self.screensaver_timeout is not None:
             GLib.source_remove(self.screensaver_timeout)

--- a/screen.py
+++ b/screen.py
@@ -619,7 +619,8 @@ class KlipperScreen(Gtk.Window):
             self.set_dpms(False)
             return False
         elif state != functions.DPMS_State.On:
-            self.screensaver.show()
+            if not self.screensaver.is_showing():
+                self.screensaver.show()
         return True
 
     def wake_screen(self):


### PR DESCRIPTION
When the screensaver is active and the screen is turned off due to DPMS the unconditional call to self.screensaver.show wakes the screen up again.
The check whether the screensaver is already active got lost in the refactor.

Fixes #1504