### PR TITLE
Spoolman Panel: Include Comments for Spools

### DIFF
--- a/panels/spoolman.py
+++ b/panels/spoolman.py
@@ -335,6 +335,8 @@ class Panel(ScreenPanel):
             result = f'<big><b>{spool.name}</b></big>\n'
         else:
             result = f'<big>{spool.name}</big>\n'
+        if hasattr(spool, "comment"):
+            result += f'{_("Comment")}:<b> {spool.comment}</b>\n'
         if spool.last_used:
             result += f'{_("Last used")}:<b> {spool.last_used.astimezone():{self.timeFormat}}</b>\n'
         if hasattr(spool, "remaining_weight"):


### PR DESCRIPTION
It simply adds the comment information from Spoolman under the spool's name, provided there is a comment associated with that spool.
![KlipperScreen_SpoolMan_Comment_1](https://github.com/user-attachments/assets/34f3a0fe-1af0-4da5-86b4-664c564a3f70)

![KlipperScreen_SpoolMan_Comment_2](https://github.com/user-attachments/assets/92a69580-e7a3-48cb-8d99-fb0cc8851b7d)

This is useful if you have multiple printers and use the same brand ,type, and color of filament on each printer.
