### PR TITLE
Fix heater graph not rendering by skipping data points that are None

### DIFF
--- a/ks_includes/widgets/heatergraph.py
+++ b/ks_includes/widgets/heatergraph.py
@@ -132,7 +132,7 @@ class HeaterGraph(Gtk.DrawingArea):
         for i, d in enumerate(data):
             if d is None:
                 continue
-                
+
             p_x = i * swidth + gsize[0][0] if i != d_len else gsize[1][0] - 1
             if dashed:  # d between 0 and 1
                 p_y = gsize[1][1] - (d * (gsize[1][1] - gsize[0][1]))

--- a/ks_includes/widgets/heatergraph.py
+++ b/ks_includes/widgets/heatergraph.py
@@ -71,10 +71,10 @@ class HeaterGraph(Gtk.DrawingArea):
             if self.store[device]['show']:
                 temp = self.printer.get_temp_store(device, "temperatures", data_points)
                 if isinstance(temp, list):
-                    mnum.append(max(temp))
+                    mnum.append(max([v for v in temp if v is not None]))
                 target = self.printer.get_temp_store(device, "targets", data_points)
                 if isinstance(target, list):
-                    mnum.append(max(target))
+                    mnum.append(max([v for v in target if v is not None]))
         return max(mnum)
 
     def draw_graph(self, da: Gtk.DrawingArea, ctx: cairoContext):
@@ -130,6 +130,9 @@ class HeaterGraph(Gtk.DrawingArea):
         d_len = len(data) - 1
 
         for i, d in enumerate(data):
+            if d is None:
+                continue
+                
             p_x = i * swidth + gsize[0][0] if i != d_len else gsize[1][0] - 1
             if dashed:  # d between 0 and 1
                 p_y = gsize[1][1] - (d * (gsize[1][1] - gsize[0][1]))

--- a/ks_includes/widgets/heatergraph.py
+++ b/ks_includes/widgets/heatergraph.py
@@ -129,11 +129,16 @@ class HeaterGraph(Gtk.DrawingArea):
             ctx.set_dash([1, 0])
         d_len = len(data) - 1
 
+        start_x = gsize[1][0]
+        end_x = gsize[0][0]
+
         for i, d in enumerate(data):
             if d is None:
                 continue
 
             p_x = i * swidth + gsize[0][0] if i != d_len else gsize[1][0] - 1
+            start_x = min(start_x, p_x)
+            end_x = max(end_x, p_x)
             if dashed:  # d between 0 and 1
                 p_y = gsize[1][1] - (d * (gsize[1][1] - gsize[0][1]))
             else:
@@ -143,8 +148,8 @@ class HeaterGraph(Gtk.DrawingArea):
             ctx.line_to(p_x, p_y)
         if fill:
             ctx.stroke_preserve()
-            ctx.line_to(gsize[1][0] - 1, gsize[1][1] - 1)
-            ctx.line_to(gsize[0][0] + 1, gsize[1][1] - 1)
+            ctx.line_to(end_x - 1, gsize[1][1] - 1)
+            ctx.line_to(start_x + 1, gsize[1][1] - 1)
             ctx.fill()
         else:
             ctx.stroke()


### PR DESCRIPTION
When there are data points in the temperature store that are None, the heater graph fails to render with an error like this:
```
2025-01-31 21:32:36,705 [functions.py:logging_exception_handler()] - Uncaught exception <class 'TypeError'>: '>' not supported between instances of 'NoneType' and 'float'
  File "/home/paulg/KlipperScreen/ks_includes/widgets/heatergraph.py", line 100, in draw_graph
    max_num = math.ceil(self.get_max_num(data_points) * 1.1 / 10) * 10

  File "/home/paulg/KlipperScreen/ks_includes/widgets/heatergraph.py", line 74, in get_max_num
    mnum.append(max(temp))
```
and
```
2025-01-31 21:34:01,713 [functions.py:logging_exception_handler()] - Uncaught exception <class 'TypeError'>: unsupported operand type(s) for *: 'NoneType' and 'float'
  File "/home/paulg/KlipperScreen/ks_includes/widgets/heatergraph.py", line 116, in draw_graph
    self.graph_data(

  File "/home/paulg/KlipperScreen/ks_includes/widgets/heatergraph.py", line 139, in graph_data
    p_y = max(gsize[0][1], min(gsize[1][1], gsize[1][1] - 1 - (d * hscale)))
```
This happened in my case after I added a temperature sensor to my printer. Since there were no data points before that, it defaulted to None, causing the error.
I would suggest fixing this by checking for None and skipping those points. See the changes

~ Paul