### PR TITLE
fix: Start PAM session in service to allow Wayland start at boot

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -37,7 +37,7 @@ install_graphical_backend()
       echo_text ""
       echo_text "Choose graphical backend"
       echo_ok "Default is Xserver"
-      echo_text "Wayland is EXPERIMENTAL needs kms/drm drivers doesn't support DPMS and may need autologin"
+      echo_text "Wayland is EXPERIMENTAL, needs kms/drm drivers, and doesn't support DPMS"
       echo_text ""
       echo "Press enter for default (Xserver)"
       read -r -e -p "Backend Xserver or Wayland (cage)? [X/w]" BACKEND

--- a/scripts/KlipperScreen.service
+++ b/scripts/KlipperScreen.service
@@ -25,6 +25,8 @@ ExecStart="KS_DIR/scripts/KlipperScreen-start.sh"
 # 'who'. This is needed since we replace (a)getty.
 UtmpIdentifier=tty7
 UtmpMode=user
+# Create a PAM session to run pam-systemd, which creates /var/run/$UID
+PAMName=%u
 # A virtual terminal is needed.
 TTYPath=/dev/tty7
 TTYReset=yes


### PR DESCRIPTION
https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PAMName=

Fixes #1548