### PR TITLE
fix: turn on power_devices associated with screen on startup

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -1148,6 +1148,7 @@ class KlipperScreen(Gtk.Window):
         self.ws_subscribe()
 
         self.files.set_gcodes_path()
+        self.power_devices(None, self._config.get_main_config().get("screen_on_devices", ""), on=True)
 
         logging.info("Printer initialized")
         self.initialized = True


### PR DESCRIPTION
if the power devices associated with screen were off and KS was restarted they would have remained off

this is intended for screens that have the backlight attached to a moonraker power device instead of the OS