### PR TITLE
fix(systemd): enable stopping with `systemctl stop`

### DIFF
--- a/scripts/KlipperScreen-start.sh
+++ b/scripts/KlipperScreen-start.sh
@@ -13,9 +13,9 @@ fi
 
 if [[ "$BACKEND" =~ ^[wW]$ ]]; then
     echo "Running KlipperScreen on Cage"
-    /usr/bin/cage -ds $KS_XCLIENT
+    exec /usr/bin/cage -ds $KS_XCLIENT
 
 else
     echo "Running KlipperScreen on X in display :0 by default"
-    /usr/bin/xinit $KS_XCLIENT
+    exec /usr/bin/xinit $KS_XCLIENT
 fi


### PR DESCRIPTION
Prior to this commit, `systemctl stop KlipperScreen` would result in only KlipperScreen-start.sh being killed, leaving the graphical session running as an abandoned process.

Launching the GUI process with `exec` lets systemd manage it.