### PR TITLE
Time format improvement

### DIFF
--- a/ks_includes/screen_panel.py
+++ b/ks_includes/screen_panel.py
@@ -133,20 +133,39 @@ class ScreenPanel:
         spc = "\u00A0"  # Non breakable space
         if seconds is None or seconds < 1:
             return "-"
+
         days = seconds // 86400
+        secondsRemaining = seconds - (days * 86400)
+        hours = secondsRemaining // 3600
+        secondsRemaining = secondsRemaining - (hours * 3600)
+        minutes = secondsRemaining // 60
+        secondsRemaining = secondsRemaining - (minutes * 60)
+
+        # Round 60 seconds up a minute
+        if secondsRemaining > 59:
+            minutes += 1
+            secondsRemaining = 0
+
+        # If we've rounded to 60 minutes or more than 59m30s round up an hour
+        if minutes > 59 or (minutes == 59 and secondsRemaining >= 30):
+            hours += 1
+            minutes = 0
+
+        # If we've rounded to 24 hours or more than 23h30m round up a day
+        if hours > 23 or (hours >= 23 and minutes >= 30):
+            days += 1
+            hours = 0
+
+        # Determine all of the units after adjustments
         day_units = ngettext("day", "days", days)
-        seconds %= 86400
-        hours = seconds // 3600
         hour_units = ngettext("hour", "hours", hours)
-        seconds %= 3600
-        minutes = round(seconds / 60)
         min_units = ngettext("minute", "minutes", minutes)
-        seconds %= 60
-        sec_units = ngettext("second", "seconds", seconds)
+        sec_units = ngettext("second", "seconds", secondsRemaining)
+
         return f"{f'{days:2.0f}{spc}{day_units}{spc}' if days > 0 else ''}" \
                f"{f'{hours:2.0f}{spc}{hour_units}{spc}' if hours > 0 else ''}" \
                f"{f'{minutes:2.0f}{spc}{min_units}{spc}' if minutes > 0 and days == 0 else ''}" \
-               f"{f'{seconds:2.0f}{spc}{sec_units}' if days == 0 and hours == 0 and minutes == 0 else ''}"
+               f"{f'{secondsRemaining:2.0f}{spc}{sec_units}' if days == 0 and hours == 0 else ''}"
 
     def format_eta(self, total, elapsed):
         if total is None:

--- a/ks_includes/screen_panel.py
+++ b/ks_includes/screen_panel.py
@@ -165,7 +165,7 @@ class ScreenPanel:
         return f"{f'{days:2.0f}{spc}{day_units}{spc}' if days > 0 else ''}" \
                f"{f'{hours:2.0f}{spc}{hour_units}{spc}' if hours > 0 else ''}" \
                f"{f'{minutes:2.0f}{spc}{min_units}{spc}' if minutes > 0 and days == 0 else ''}" \
-               f"{f'{secondsRemaining:2.0f}{spc}{sec_units}' if days == 0 and hours == 0 else ''}"
+               f"{f'{secondsRemaining:2.0f}{spc}{sec_units}' if days == 0 and hours == 0 and secondsRemaining > 0 else ''}"
 
     def format_eta(self, total, elapsed):
         if total is None:

--- a/ks_includes/screen_panel.py
+++ b/ks_includes/screen_panel.py
@@ -152,7 +152,7 @@ class ScreenPanel:
             minutes = 0
 
         # If we've rounded to 24 hours or more than 23h30m round up a day
-        if hours > 23 or (hours >= 23 and minutes >= 30):
+        if hours > 23 or (hours == 23 and minutes >= 30):
             days += 1
             hours = 0
 


### PR DESCRIPTION
The current implementation results in displays of time such as "1 hour 60 minutes", this change provides an opinionated time formatter with some appropriate rounding that avoids displaying such times.

Seconds are reintroduced for times less than an hour, and the last 30 seconds of an hour and the last 30 minutes of a day are also rounded up.

```
    print(format_time(58)) # 58 seconds
    print(format_time(59)) # 59 seconds
    print(format_time(60)) # 1 minute

    print(format_time((59*60) + 29)) # 59 minutes
    print(format_time((59*60) + 30)) # 1h
    print(format_time((59*60) + 58)) # 1h
    print(format_time((59*60) + 59)) # 1h

    print(format_time((23*3600) + (29*60))) # 23h 29m
    print(format_time((23*3600) + (30*60))) # 1d
    print(format_time((23*3600) + (59*60))) # 1d

    print(format_time(86400 + (23*3600) + (29*60))) # 1d 23h
    print(format_time(86400 + (23*3600) + (30*60))) # 2d
    print(format_time(86400 + (23*3600) + (59*60))) # 2d
```
output:
```
58 seconds
59 seconds
 1 minute 
59 minutes 29 seconds
 1 hour 
 1 hour 
 1 hour 
23 hours 29 minutes 
 1 day 
 1 day 
 1 day 23 hours 
 2 days 
 2 days 
```