### PR TITLE
Fix keyboard popup in Wayland/Cage

### DIFF
--- a/ks_includes/widgets/lockscreen.py
+++ b/ks_includes/widgets/lockscreen.py
@@ -43,7 +43,7 @@ class LockScreen:
         entry = Gtk.Entry(hexpand=True, vexpand=False, placeholder_text=_("Password"))
         entry.set_input_purpose(Gtk.InputPurpose.PASSWORD)
         entry.set_visibility(False)
-        entry.connect("focus-in-event", self.screen.show_keyboard, box, self.relock)
+        entry.connect("touch-event", self.screen.show_keyboard, box, self.relock)
         entry.connect("activate", self.unlock_attempt, entry)
         entry.get_style_context().add_class("lockscreen_entry")
         entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "view-reveal-symbolic")

--- a/panels/bed_mesh.py
+++ b/panels/bed_mesh.py
@@ -210,7 +210,7 @@ class Panel(ScreenPanel):
             pl = Gtk.Label(label=_("Profile Name:"), hexpand=False)
             self.labels['profile_name'] = Gtk.Entry(hexpand=True, text='')
             self.labels['profile_name'].connect("activate", self.create_profile)
-            self.labels['profile_name'].connect("focus-in-event", self._screen.show_keyboard)
+            self.labels['profile_name'].connect("touch-event", self._screen.show_keyboard)
 
             save = self._gtk.Button("complete", _("Save"), "color3")
             save.set_hexpand(False)

--- a/panels/console.py
+++ b/panels/console.py
@@ -42,7 +42,7 @@ class Panel(ScreenPanel):
         tb = Gtk.TextBuffer()
         tv = Gtk.TextView(buffer=tb, editable=False, cursor_visible=False)
         tv.connect("size-allocate", self._autoscroll)
-        tv.connect("focus-in-event", self._screen.remove_keyboard)
+        tv.connect("touch-event", self._screen.remove_keyboard)
 
         sw.add(tv)
 
@@ -50,7 +50,7 @@ class Panel(ScreenPanel):
 
         entry = Gtk.Entry(hexpand=True, vexpand=False)
         entry.connect("button-press-event", self._screen.show_keyboard)
-        entry.connect("focus-in-event", self._screen.show_keyboard)
+        entry.connect("touch-event", self._screen.show_keyboard)
         entry.connect("activate", self._send_command)
         entry.grab_focus_without_selecting()
 

--- a/panels/gcode_macros.py
+++ b/panels/gcode_macros.py
@@ -110,7 +110,7 @@ class Panel(ScreenPanel):
 
         for param in self.macros[macro]["params"]:
             labels.add(Gtk.Label(param))
-            self.macros[macro]["params"][param].connect("focus-in-event", self.show_keyboard)
+            self.macros[macro]["params"][param].connect("touch-event", self.show_keyboard)
             self.macros[macro]["params"][param].connect("focus-out-event", self._screen.remove_keyboard)
             labels.add(self.macros[macro]["params"][param])
 

--- a/panels/gcodes.py
+++ b/panels/gcodes.py
@@ -525,7 +525,7 @@ class Panel(ScreenPanel):
         lbl = Gtk.Label(label=_("Rename/Move:"), halign=Gtk.Align.START, hexpand=False)
         self.labels['new_name'] = Gtk.Entry(text=fullpath, hexpand=True)
         self.labels['new_name'].connect("activate", self.rename)
-        self.labels['new_name'].connect("focus-in-event", self._screen.show_keyboard)
+        self.labels['new_name'].connect("touch-event", self._screen.show_keyboard)
 
         save = self._gtk.Button("complete", _("Save"), "color3")
         save.set_hexpand(False)

--- a/panels/network.py
+++ b/panels/network.py
@@ -306,11 +306,11 @@ class Panel(ScreenPanel):
         auth_selection_box.add(self.labels['network_phase2'])
 
         self.labels['network_identity'] = Gtk.Entry(hexpand=True, no_show_all=True)
-        self.labels['network_identity'].connect("focus-in-event", self._screen.show_keyboard)
+        self.labels['network_identity'].connect("touch-event", self._screen.show_keyboard)
 
         self.labels['network_psk'] = Gtk.Entry(hexpand=True)
         self.labels['network_psk'].connect("activate", self.add_new_network, ssid)
-        self.labels['network_psk'].connect("focus-in-event", self._screen.show_keyboard)
+        self.labels['network_psk'].connect("touch-event", self._screen.show_keyboard)
 
         save = self._gtk.Button("sd", _("Save"), "color3")
         save.set_hexpand(False)


### PR DESCRIPTION
Inside Cage (possibly any Wayland context?), the keyboard doesn't pop up. Strangely, the keypad does.

I tracked it down to `focus-in-event`, which doesn't appear to be triggered when touching an item such as the PSK password entry widget, whereas `touch-event` does.

I've tested this fork with X11 and the keyboard still pops up and submits the correct data, so it *appears* that this is safe, but I defer to your expertise as there may be other side-effects.