### PR TITLE
installer: fix polkit rule file

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -232,7 +232,6 @@ polkit.addRule(function(action, subject) {
         subject.user == "$USER") {
         return polkit.Result.YES;
         }
-    }
 });
 EOF
 }


### PR DESCRIPTION
Since 40ce34f (the removal of the try-catch block in the polkit rule file), there is one extra `}` character that leads to polkitd logging a syntax error and ignoring the rule.