### PR TITLE
panels: extrude: replace 25mm/s speed with 10mm/s

### DIFF
--- a/panels/extrude.py
+++ b/panels/extrude.py
@@ -21,7 +21,7 @@ class Panel(ScreenPanel):
         self.load_filament = any("LOAD_FILAMENT" in macro.upper() for macro in macros)
         self.unload_filament = any("UNLOAD_FILAMENT" in macro.upper() for macro in macros)
 
-        self.speeds = ['1', '2', '5', '25']
+        self.speeds = ['1', '2', '5', '10']
         self.distances = ['5', '10', '15', '25']
         if self.ks_printer_cfg is not None:
             dis = self.ks_printer_cfg.get("extrude_distances", '')


### PR DESCRIPTION
25mm/s *1.75mm = 43.75mm^3/s volumetric speed. Not a lot of hotends can reach it. Replace it with 10mm/s instead, which is 17.5mm^3/s and is achievable with most of modern hotends