### PR TITLE
Add caching for icons and pixbufs

### DIFF
--- a/ks_includes/KlippyGtk.py
+++ b/ks_includes/KlippyGtk.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import pathlib
+from functools import lru_cache
 
 import gi
 
@@ -126,15 +127,21 @@ class KlippyGtk:
     def PixbufFromIcon(self, filename, width=None, height=None):
         width = width if width is not None else self.img_width
         height = height if height is not None else self.img_height
-        filename = os.path.join(self.themedir, filename)
+        return self._PixbufFromIcon(filename, self.themedir, int(width), int(height))
+
+    @staticmethod
+    @lru_cache(maxsize=500)
+    def _PixbufFromIcon(filename, themedir, width, height):
+        filename = os.path.join(themedir, filename)
         for ext in ["svg", "png"]:
             file = f"{filename}.{ext}"
-            pixbuf = self.PixbufFromFile(file, int(width), int(height)) if os.path.exists(file) else None
+            pixbuf = KlippyGtk.PixbufFromFile(file, width, height) if os.path.exists(file) else None
             if pixbuf is not None:
                 return pixbuf
         return None
 
     @staticmethod
+    @lru_cache(maxsize=500)
     def PixbufFromFile(filename, width=-1, height=-1):
         try:
             return GdkPixbuf.Pixbuf.new_from_file_at_size(filename, int(width), int(height))


### PR DESCRIPTION
Profiling showed that a lot of time being spent repeatedly creating pixbufs for the same icons when loading panels. This change significantly improves responsiveness, especially on slower hosts.

Before:
<img width="2471" height="1280" alt="speedscope before" src="https://github.com/user-attachments/assets/0028ae9f-db5b-464f-b926-af6b343a193f" />

After:
<img width="2471" height="1280" alt="speedscope after" src="https://github.com/user-attachments/assets/ff817dab-d7a1-4a86-b149-b88485d6f281" />
