### PR TITLE
Make notification popovers non-modal

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -505,7 +505,7 @@ class KlipperScreen(Gtk.ApplicationWindow):
             halign=Gtk.Align.CENTER,
             width_request=int(self.width * 0.9),
         )
-        popup.set_modal(level != 1)
+        popup.set_modal(False)
         popup.get_style_context().add_class("message_popup_popover")
         popup.add(msg)
         popup.popup()

--- a/screen.py
+++ b/screen.py
@@ -505,6 +505,7 @@ class KlipperScreen(Gtk.ApplicationWindow):
             halign=Gtk.Align.CENTER,
             width_request=int(self.width * 0.9),
         )
+        popup.set_modal(level != 1)
         popup.get_style_context().add_class("message_popup_popover")
         popup.add(msg)
         popup.popup()


### PR DESCRIPTION
Fixes #1748

## What changed

All notification popovers are now non-modal, regardless of notification level. Success, warning, and error notifications retain their existing styling and timeout behaviour, but no longer capture touchscreen input.

## Why

KlipperScreen uses `Gtk.Popover` for notification messages. GTK popovers are modal by default, which means a visible notification can block interaction with the underlying interface until it is dismissed or times out.

Making all notification popovers non-modal gives the different notification levels consistent interaction behaviour and ensures notifications do not interfere with normal user control. Dedicated error dialogs remain modal where explicit user acknowledgement is required.

## Validation

- `python -m py_compile screen.py`
- `git diff --check`
- Reproduced on official KlipperScreen `v0.4.7`; see issue #1748 and its attached startup-to-reproduction log.