### PR TITLE
fix: switch to configured VT before starting service

### DIFF
--- a/scripts/KlipperScreen.service
+++ b/scripts/KlipperScreen.service
@@ -20,6 +20,7 @@ SupplementaryGroups=klipperscreen
 WorkingDirectory=KS_DIR
 Environment="KS_XCLIENT=KS_ENV/bin/python KS_DIR/screen.py" BACKEND=KS_BACKEND
 ExecStart="KS_DIR/scripts/KlipperScreen-start.sh"
+ExecStartPost=+chvt 7
 
 # Log this user with utmp, letting it show up with commands 'w' and
 # 'who'. This is needed since we replace (a)getty.


### PR DESCRIPTION
When using KlipperScreen with Cage/Wayland, Cage starts on the currently active VT despite `TTYPath` being set to /dev/tty7.

This PR fixes the issue by switching to the configured VT before Cage initializes its DRM/KMS session, ensuring that KlipperScreen always starts on the intended VT.

My tests showed that this change is only required for the Cage/Wayland backend; the X11 backend is unaffected.