### PR TITLE
Skip Cage installation when already installed

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -44,6 +44,12 @@ install_graphical_backend()
       read -r -e -p "Backend X11 or Wayland (cage)? [X/w]" BACKEND
     fi
     if [[ "$BACKEND" =~ ^[wW]$ ]]; then
+        if command -v cage >/dev/null 2>&1; then
+            echo_ok "Cage already installed"
+            BACKEND="W"
+            break
+        fi
+
         echo_text "Installing Cage"
         if sudo apt install -y $CAGE; then
             echo_ok "Installed Cage"


### PR DESCRIPTION
When Wayland/Cage is selected, the installer currently attempts to install Cage even when it is already available on the system.

This change checks whether the `cage` executable is already present and skips the installation when it is.