### PR TITLE
Detect virtual terminal availability during install

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -80,7 +80,7 @@ check_virtual_terminal()
     fi
 
     if [ -e /sys/class/tty/tty7 ] && [ -c /dev/tty7 ]; then
-        MISC+=" kdb"
+        MISC+=" kbd"
         echo_ok "Virtual terminal is available"
     else
         echo_text "No usable virtual terminal detected, disabling related configuration"

--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -87,6 +87,12 @@ check_virtual_terminal()
         sudo sed -i \
             -e '/^ConditionPathExists=/s/^/#/' \
             -e '/^ExecStartPost=/s/^/#/' \
+            -e '/^UtmpIdentifier=/s/^/#/' \
+            -e '/^UtmpMode=/s/^/#/' \
+            -e '/^TTYPath=/s/^/#/' \
+            -e '/^TTYReset=/s/^/#/' \
+            -e '/^TTYVHangup=/s/^/#/' \
+            -e '/^TTYVTDisallocate=/s/^/#/' \
             "$service_file"
     fi
 }

--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -68,6 +68,29 @@ install_graphical_backend()
   done
 }
 
+check_virtual_terminal()
+{
+    echo_text "Checking for working virtual terminal"
+
+    local service_file="/etc/systemd/system/KlipperScreen.service"
+
+    if [ ! -f "$service_file" ]; then
+        echo_error "The service file '$service_file' doesn't exist"
+        exit 1
+    fi
+
+    if [ -e /sys/class/tty/tty7 ] && [ -c /dev/tty7 ]; then
+        MISC+=" kdb"
+        echo_ok "Virtual terminal is available"
+    else
+        echo_text "No usable virtual terminal detected, disabling related configuration"
+        sudo sed -i \
+            -e '/^ConditionPathExists=/s/^/#/' \
+            -e '/^ExecStartPost=/s/^/#/' \
+            "$service_file"
+    fi
+}
+
 install_packages()
 {
     echo_text "Update package data"
@@ -342,6 +365,7 @@ if [[ $SERVICE =~ ^[nN]$ ]]; then
 else
     install_graphical_backend
     install_systemd_service
+    check_virtual_terminal
     if [ -z "$START" ]; then
         START=1
     fi

--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -84,7 +84,7 @@ check_virtual_terminal()
         echo_ok "Virtual terminal is available"
     else
         echo_text "No usable virtual terminal detected, disabling related configuration"
-        sudo sed -i \
+        if sudo sed -i \
             -e '/^ConditionPathExists=/s/^/#/' \
             -e '/^ExecStartPost=/s/^/#/' \
             -e '/^UtmpIdentifier=/s/^/#/' \
@@ -93,7 +93,12 @@ check_virtual_terminal()
             -e '/^TTYReset=/s/^/#/' \
             -e '/^TTYVHangup=/s/^/#/' \
             -e '/^TTYVTDisallocate=/s/^/#/' \
-            "$service_file"
+            "$service_file"; then
+            echo_ok "Disabled VT-related configuration"
+        else
+            echo_error "Failed to disable VT-related configuration in '$service_file'"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
This pull request adds a check for available virtual terminals to the installation script.

Commit d045dfe / PR #1756 introduced a small change to the handling of virtual terminals in the `KlipperScreen.service` file, which is not suited for every environment and led to issues.
To resolve this, the installer checks for the existence of the required tty only if installing as a service. There are two possible outcomes:

1. A virtual terminal is detected, which adds the package `kdb` to the installation sources (see #1763)
2. No virtual terminal is detected, which disabled VT-related configurations in the `KlipperScreen.service` file

This should allow for more dynamic handling of different environments. 

Resolves #1763 