### PR TITLE
fix: install kbd for chvt service command

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -8,7 +8,7 @@ XSERVER="xinit xinput x11-xserver-utils xserver-xorg-input-evdev xserver-xorg-in
 CAGE="cage seatd"
 WESTON="weston seatd"
 PYGOBJECT="libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0"
-MISC="librsvg2-common libopenjp2-7 libdbus-glib-1-dev autoconf python3-venv"
+MISC="librsvg2-common libopenjp2-7 libdbus-glib-1-dev autoconf python3-venv kbd"
 OPTIONAL="fonts-nanum fonts-ipafont libmpv-dev"
 
 Red='\033[0;31m'

--- a/scripts/system-dependencies.json
+++ b/scripts/system-dependencies.json
@@ -12,7 +12,8 @@
         "librsvg2-common",
         "libopenjp2-7",
         "libdbus-glib-1-dev",
-        "autoconf"
+        "autoconf",
+        "kbd"
     ],
     "arch": [
         "cairo",
@@ -25,6 +26,7 @@
         "librsvg",
         "openjpeg2",
         "dbus-glib",
-        "autoconf"
+        "autoconf",
+        "kbd"
     ]
 }


### PR DESCRIPTION
Commit `d045dfed` added `ExecStartPost=+chvt 7` to the KlipperScreen systemd service. However, the package providing `chvt` is not currently included in the installation dependencies.

On minimal Debian/Ubuntu installations where `kbd` is not already installed, this prevents KlipperScreen from starting and causes an endless restart loop:

As discussed in #1763 

```text
KlipperScreen.service: Control process exited, code=exited, status=203/EXEC
KlipperScreen.service: Failed with result 'exit-code'.